### PR TITLE
remove noisy log line

### DIFF
--- a/common.go
+++ b/common.go
@@ -82,7 +82,6 @@ func (ms *ModelSetup) simpleText(text string, clr string, fontSize float64) []st
 			FontSize:  fontSize,
 			FontColor: getColor(clr, "white"),
 		}
-		fmt.Printf("hi %v\n", tl)
 		tls = append(tls, tl)
 	}
 


### PR DESCRIPTION
Right now every time the keys are updated (which is at each stage of a pass), I'm seeing all the new keys printed like this:

```

8/28/2025, 3:51:23 PM info rdk.modmanager.viam_sanding-streamdeck.StdOut   pexec/managed_process.go:411   \_ hi {reboot 5 0 <nil> 16 {255 255 255 255}}

8/28/2025, 3:51:23 PM info rdk.modmanager.viam_sanding-streamdeck.StdOut   pexec/managed_process.go:411   \_ hi {cancel 5 0 <nil> 16 {255 255 255 255}}

8/28/2025, 3:51:23 PM info rdk.modmanager.viam_sanding-streamdeck.StdOut   pexec/managed_process.go:411   \_ hi {combined 5 12 <nil> 12 {255 255 255 255}}

8/28/2025, 3:51:23 PM info rdk.modmanager.viam_sanding-streamdeck.StdOut   pexec/managed_process.go:411   \_ hi {plan 5 0 <nil> 12 {255 255 255 255}}

8/28/2025, 3:51:23 PM info rdk.modmanager.viam_sanding-streamdeck.StdOut   pexec/managed_process.go:411   \_ hi {separate 5 12 <nil> 12 {255 255 255 255}}

8/28/2025, 3:51:23 PM info rdk.modmanager.viam_sanding-streamdeck.StdOut   pexec/managed_process.go:411   \_ hi {plan 5 0 <nil> 12 {255 255 255 255}}

8/28/2025, 3:51:23 PM info rdk.modmanager.viam_sanding-streamdeck.StdOut   pexec/managed_process.go:411   \_ hi {whole 5 18 <nil> 18 {255 255 255 255}}

8/28/2025, 3:51:23 PM info rdk.modmanager.viam_sanding-streamdeck.StdOut   pexec/managed_process.go:411   \_ hi {plan 5 0 <nil> 18 {255 255 255 255}}
```