### PR TITLE
assign new config as streamdecks config

### DIFF
--- a/simple.go
+++ b/simple.go
@@ -104,6 +104,7 @@ func (sdc *streamdeckComponent) reconfigure(ctx context.Context, deps resource.D
 	defer sdc.configLock.Unlock()
 
 	sdc.deps = deps
+	sdc.conf = newConf
 
 	err := sdc.updateBrightness(newConf.Brightness)
 	if err != nil {


### PR DESCRIPTION
Problem: Stream Deck was not reconfiguring correctly.
Investigation: `reconfigure()` doesn't actually set the new config as the stream deck's config. Assuming that `stateChecker()` then calls reconfig with the old config
Solution: Set the new config as the stream deck's config on reconfigure.